### PR TITLE
fix  After the network port is up, DHCP takes too long to obtain an IP address 

### DIFF
--- a/board/canaan/k510/k510_rootfs_skeleton/etc/init.d/rc.sysinit
+++ b/board/canaan/k510/k510_rootfs_skeleton/etc/init.d/rc.sysinit
@@ -106,3 +106,4 @@ i2ctransfer -f -y 0 w3@0x10 0x01 0x00 0x00
 cd /app/mediactl_lib/
 ./v4l2_drm.out -f video_drm_1080x1920.conf -e 1 &
 cd /
+/usr/sbin/ifplugd   -n -p  -I -i eth0 -r /etc/network/ifplug.sh &

--- a/board/canaan/k510/k510_rootfs_skeleton/etc/network/ifplug.sh
+++ b/board/canaan/k510/k510_rootfs_skeleton/etc/network/ifplug.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+#set -x
+#echo "$0 $# is $*"
+if [ "$1" = "eth0" ]; then 
+	if [ "$2" = "up" ]; then 
+		ifdown  eth0;
+		ifup  eth0;		
+	fi;
+fi
+#/usr/sbin/ifplugd   -n -p  -I -i eth0 -r /etc/network/ifplug.sh &


### PR DESCRIPTION
<!--
请按照以下要求填写此PR模板
1. 根据此PR的类型在右侧'Labels'位置添加对应的label。比如此PR修复了某个bug，则添加'bug'label；此PR新增了某个feature，则添加'feature'label。
2. 在'PR描述'项里填写此PR解决了什么问题，比如修复了某个bug或新增了某个feature。
3. 在'详细描述'项里根据PR类型填写详细信息。比如此PR修复了某个bug，则填写bug的根本原因，您是如何解决的；此PR新增了某个feature，则填写您是如何实现的。
4. 在'关联issue'项里填写相关issue号(输入'#'会自动提示issue)，推荐使用'close'、'fix'、'resolve'等关键字进行自动关联(如'fix #1')，也可以提交PR后在右侧'Development'中进行手动关联。
-->

## PR描述:
fix: After the network port is up, DHCP takes too long to obtain an IP address 

## 详细描述:
 After the network port is up, DHCP takes too long to obtain an IP address 

## 关联issue:
#114 
