### PR TITLE
fix rtc-kendryte code error , sd bootcmd modify to loop, lcd id read fialed reboot board

### DIFF
--- a/board/canaan/k510/uboot-sdcard.env
+++ b/board/canaan/k510/uboot-sdcard.env
@@ -14,5 +14,5 @@ gatewayip=10.100.226.254
 serverip=10.100.226.63
 bootargs=root=/dev/mmcblk2p2 ro console=ttyS0,115200n8 debug loglevel=7 rootfstype=ext2
 
-bootcmd=fatload mmc 1:1 0x600000 bootm-bbl.img;fatload mmc 1:1 0x2000000 k510.dtb;bootm 0x600000 - 0x2000000
+bootcmd=while  true ; do  fatload mmc 1:1 0x600000 bootm-bbl.img && fatload mmc 1:1 0x2000000 k510.dtb && bootm 0x600000 - 0x2000000 ;done
 bootcmd_nfs=tftp 0x600000 bootm-bbl.img;tftp 0x2000000 k510_nfsroot.dtb;bootm 0x600000 - 0x2000000

--- a/package/patches/linux/0021-fix-kendryte-rtc-driver-code-error.patch
+++ b/package/patches/linux/0021-fix-kendryte-rtc-driver-code-error.patch
@@ -1,0 +1,34 @@
+From 29675aced5a28c6621de02d3798c276e32d5de28 Mon Sep 17 00:00:00 2001
+From: wangjianxin <wangjianxin@canaan-creative.com>
+Date: Wed, 27 Jul 2022 17:39:51 +0800
+Subject: [PATCH] fix kendryte-rtc driver code error
+
+---
+ drivers/rtc/rtc-kendryte.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/rtc/rtc-kendryte.c b/drivers/rtc/rtc-kendryte.c
+index 6f1f952b..e6f5ec52 100755
+--- a/drivers/rtc/rtc-kendryte.c
++++ b/drivers/rtc/rtc-kendryte.c
+@@ -358,7 +358,7 @@ static int kendryte_rtc_setaie(struct device *dev, unsigned int enabled)
+ {
+ 	struct kendryte_rtc *rtc = dev_get_drvdata(dev);
+ 	
+-	printk( "k510_rtc set aie enabled is %d \n", enabled);
++	//printk( "k510_rtc set aie enabled is %d \n", enabled);
+ 	
+ 	if(enabled){
+ 		kendryte_rtc_alarm_set_interrupt(rtc, 1);
+@@ -397,7 +397,7 @@ static irqreturn_t kendryte_rtc_alarmirq(int irq, void *id)
+ /* IRQ Handlers */
+ static irqreturn_t kendryte_rtc_tickirq(int irq, void *id)
+ {
+-	struct kendryte_rtc *rtc = (struct kendryte_rtc *)rtc;
++	struct kendryte_rtc *rtc = (struct kendryte_rtc *)id;
+ 
+ 	printk("this is tickirq \n");
+ 	
+-- 
+2.30.2
+

--- a/package/patches/uboot/0009-uboot-lcd-init-faile-reboot-board.patch
+++ b/package/patches/uboot/0009-uboot-lcd-init-faile-reboot-board.patch
@@ -1,0 +1,37 @@
+From a2af539e7045417493b3b10fc103a318d50c3479 Mon Sep 17 00:00:00 2001
+From: wangjianxin <wangjianxin@canaan-creative.com>
+Date: Wed, 27 Jul 2022 17:53:42 +0800
+Subject: [PATCH] uboot lcd init faile reboot board
+
+---
+ .../bsp/controler/video/mipi/dsi/cnds_dsi_test.c   | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/board/Canaan/dsi_logo/bsp/controler/video/mipi/dsi/cnds_dsi_test.c b/board/Canaan/dsi_logo/bsp/controler/video/mipi/dsi/cnds_dsi_test.c
+index 91e3e737..b248d98d 100755
+--- a/board/Canaan/dsi_logo/bsp/controler/video/mipi/dsi/cnds_dsi_test.c
++++ b/board/Canaan/dsi_logo/bsp/controler/video/mipi/dsi/cnds_dsi_test.c
+@@ -1716,11 +1716,15 @@ int32_t hx8399_read_id(void)
+         DsiRegWr(DIRECT_CMD_SEND_OFFSET, 0xffffffff);
+ 
+         while ((cmd_sts & 0x08) != 0x08) {
+-                usleep(1000);
+-                retry--;
+-                cmd_sts = DsiRegRd(DIRECT_CMD_STS_OFFSET);
+-                if (retry == 0)
+-                        return -1;
++            usleep(1000);
++            retry--;
++            cmd_sts = DsiRegRd(DIRECT_CMD_STS_OFFSET);
++            if (retry == 0){
++				printf("lcd id can not read ,reboot device \n");
++				usleep(1000);
++				writel(0x10001, 0x97000060);
++	            return -1;
++            }
+         }
+ 
+         err = DsiRegRd(DIRECT_CMD_RD_STS_OFFSET);
+-- 
+2.30.2
+


### PR DESCRIPTION
<!--
请按照以下要求填写此PR模板
1. 根据此PR的类型在右侧'Labels'位置添加对应的label。比如此PR修复了某个bug，则添加'bug'label；此PR新增了某个feature，则添加'feature'label。
2. 在'PR描述'项里填写此PR解决了什么问题，比如修复了某个bug或新增了某个feature。
3. 在'详细描述'项里根据PR类型填写详细信息。比如此PR修复了某个bug，则填写bug的根本原因，您是如何解决的；此PR新增了某个feature，则填写您是如何实现的。
4. 在'关联issue'项里填写相关issue号(输入'#'会自动提示issue)，推荐使用'close'、'fix'、'resolve'等关键字进行自动关联(如'fix #1')，也可以提交PR后在右侧'Development'中进行手动关联。
-->

## PR描述:
1.解决rtc-kendryte驱动编码错误导致的异常；
2. bootcmd修改；
3. uboot下lcd id 多次读失败后重启设备；

## 详细描述:
1. struct kendryte_rtc *rtc = (struct kendryte_rtc *)rtc; 这行代码编写错误；需要修改为
struct kendryte_rtc *rtc = (struct kendryte_rtc *)id;

2. bootcmd修改；
   修改为：bootcmd=while true ; do fatload mmc 1:1 0x600000 bootm-bbl.img && fatload mmc 1:1 0x2000000 k510.dtb && bootm 0x600000 - 0x2000000 ;done

3. uboot下lcd id 多次读失败后重启设备；

## 关联issue:

fix #238 

<!--
请将#之后的X，手动修改为PR关联的issue ID, PR合并成功后，可以自动关闭对应的issue
Example: 
fix #1
-->
