### PR TITLE
Fix cpu2dsp app running failed

### DIFF
--- a/package/dsp_scheduler/src/tasks/sample_task.c
+++ b/package/dsp_scheduler/src/tasks/sample_task.c
@@ -114,7 +114,8 @@ ScheRunType sample_task_run(void *arg)
                 task0SendMsg->id = DSP_TASK_0_PROCESS_END;
                 task0SendMsg->src_phyAddr = task0RevMsg->src_phyAddr;
                 task0SendMsg->dst_phyAddr = task0RevMsg->dst_phyAddr;
-                                
+
+                cache_wb(task0SendMsg, task0SendMsg, sizeof(TASK0_MESSAGE));                                
                 printc(pArg->ch, "%s>send message: msg_phyAddr 0x%x\n", __FUNCTION__, sendMsg.msg_phyAddr);
                 SCHE_SendMessage(&sendMsg, pArg->ch);
             }


### PR DESCRIPTION

## PR描述:
cpu2dsp app run failed

## 详细描述:
root cause: dsp message is flushed to ddr. cpu gets wrong message id.
counter measure: flush cache before sending message from dsp to cpu

## 关联issue:

fix #252

<!--
请将#之后的X，手动修改为PR关联的issue ID, PR合并成功后，可以自动关闭对应的issue
Example: 
fix #1
-->
