### PR TITLE
Fix encode_app poll error and encode time too long

### DIFF
--- a/package/encode_app/src/main.cpp
+++ b/package/encode_app/src/main.cpp
@@ -824,7 +824,7 @@ static void *encode_ch(void *arg)
       {
         if((get_time()-time)/1000000.0 >= (1000.0/pCtx->Cfg[channel].FrameRate))
         {
-          printf("warning: channel[%d]-encode one frame %.4f ms, rtsp time %.4f ms\n", channel, (time1-time)/1000000.0, (time2-time1)/1000000.0);
+          printf("warning: channel[%d]-encode one frame %.4f ms\n", channel, (get_time()-time)/1000000.0);
         }
 
         if(pCtx->enable_isp[channel] == 1)
@@ -1014,7 +1014,7 @@ int free_context(void *arg)
   free(pCtx->drop_en         );
   free(pCtx->out_framerate   );
   free(pCtx->ae_disable      );
-  free(pCtx->overflow      );
+  free(pCtx->overflow        );
 
   return 0;
 }
@@ -2514,7 +2514,7 @@ int main(int argc, char *argv[])
 
 	  printf("isolcpus = %d\n", isolcpus);
 	
-    if(isolcpus == 1)
+    if(isolcpus == 1 && pCtx->enable_rtsp[pCtx->ch_cnt-1] == 1)
     {   
       cpu_set_t cpuset;
       int ret;

--- a/package/encode_app/src/main.cpp
+++ b/package/encode_app/src/main.cpp
@@ -2027,7 +2027,6 @@ int parse_cmd(int argc, char *argv[])
       }
       pCtx->ch_en[cur_ch] = 1;
       printf("-ch%d: %d\n", cur_ch, pCtx->ch_en[cur_ch]);
-      memset(&pCtx->Cfg[cur_ch],0,sizeof(EncSettings));
     }
     else if(strcmp(argv[i], "-i") == 0)
     {      

--- a/package/live555_canaan/0010-buildroot-live555.patch
+++ b/package/live555_canaan/0010-buildroot-live555.patch
@@ -1,0 +1,79 @@
+Index: b/testProgs/IRtspServer.h
+===================================================================
+--- a/testProgs/IRtspServer.h
++++ b/testProgs/IRtspServer.h
+@@ -7,6 +7,7 @@
+ */
+ 
+ #pragma once
++#include <pthread.h>
+ 
+ enum RTSP_AUDIO_TYPE
+ {
+@@ -33,6 +34,7 @@ public:
+ 	virtual int     CreateStreamUrl(char const* streamName) = 0;//创建流地址
+ 	virtual bool    PushVideoData(unsigned char *pBuf, int nlen, unsigned long long dTime) = 0;  //视频数据(I帧带SPS，PPS，内部自动识别视频参数配置)
+ 	virtual bool    PushAudioData(unsigned char *pBuf, int nlen, unsigned long long dTime) = 0;
++	virtual void    GetThreadId(pthread_t *tid) = 0;
+ };
+ 
+ 
+Index: b/testProgs/RtspServerEX.cpp
+===================================================================
+--- a/testProgs/RtspServerEX.cpp
++++ b/testProgs/RtspServerEX.cpp
+@@ -141,9 +141,13 @@ int CRtspServerEX::Init(short sPort,bool
+ 
+ 	OutPacketBuffer::maxSize = 10000000;//max framesize
+ 	//CreateThread(NULL, 0, StartRtspEventLoop, (LPVOID)NULL, 0, NULL);
+-	pthread_t tid1;
+-	pthread_create(&tid1, NULL, StartRtspEventLoop, this);
++	
++	pthread_create(&m_tid, NULL, StartRtspEventLoop, this);
+ 
++  char name[12]; 
++  sprintf(name, "rtsp%d", sPort);
++  pthread_setname_np(m_tid, name);
++  
+ 	return 0;
+ }
+ 
+@@ -152,3 +156,9 @@ void    CRtspServerEX::SetAudioInfo(cons
+ 	m_audioInfo = audioInfo;
+ }
+ 
++void CRtspServerEX::GetThreadId(pthread_t *tid)
++{
++  *tid = m_tid;
++}
++
++
+Index: b/testProgs/RtspServerEX.h
+===================================================================
+--- a/testProgs/RtspServerEX.h
++++ b/testProgs/RtspServerEX.h
+@@ -11,7 +11,7 @@ class CRtspSourceDataObj;
+ class UsageEnvironment;
+ class RTSPServer;
+ #include"IRtspServer.h"
+-
++#include <pthread.h>
+ 
+ class CRtspServerEX:public IRtspServerEX
+ {
+@@ -24,6 +24,7 @@ public:
+ 	int     CreateStreamUrl(char const* streamName);
+ 	bool    PushVideoData(unsigned char *pBuf, int nlen, unsigned long long dTime);
+ 	bool    PushAudioData(unsigned char *pBuf, int nlen, unsigned long long dTime);
++	void    GetThreadId(pthread_t *tid);
+ 
+ protected:
+ 	static void* StartRtspEventLoop(void* pUser);
+@@ -43,6 +44,6 @@ private:
+ 	int          m_nCurUrlIndex;
+ 	RTSP_AUDIO_INFO        m_audioInfo;
+ 	bool                 m_bTransferAudio;
+-	
++	pthread_t m_tid;
+ };
+ 


### PR DESCRIPTION

## PR描述:
poll error happened when heavy loading.
After isolcpus=1, 2 channels 1080p rtsp happens encode time too long.

## 详细描述:
root cause: 
1. encode_app doesn't QBUF when buffer overflow
2. After isolcpus=1, userspace app needs to balance threads by itself.
counter measure:
1. queue all v4l2 buffers after buffer overflow
3. dispatch rtsp thread to core 1

## 关联issue:

fix #347 
