### PR TITLE
fix #386, face_recog demo share memory leak

### DIFF
--- a/package/ai/code/face_recog/insightface.cc
+++ b/package/ai/code/face_recog/insightface.cc
@@ -61,6 +61,7 @@ void insightface::prepare_memory()
     if(virtual_addr_output == MAP_FAILED) 
     {
         std::cerr << "map allocAlignMemFeOutput error" << std::endl;
+        // FIXME: memory leak, free share memory
         std::abort();
     }
 

--- a/package/ai/code/face_recog/main.cc
+++ b/package/ai/code/face_recog/main.cc
@@ -22,6 +22,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <exception>
 #include <nncase/runtime/host_runtime_tensor.h>
 #include <nncase/runtime/interpreter.h>
 #include <nncase/runtime/runtime_tensor.h>
@@ -97,6 +98,9 @@ void fun_sig(int sig)
     {
         quit.store(false);
     }
+}
+void fun_sig_abrt(int sig) {
+    exit(0);
 }
 int kbhit(void)
 {
@@ -561,7 +565,7 @@ display_cleanup:
     mtx.lock();
     video_stop(vdev);
 	video_cleanup(vdev);
-    system("killall -9 face_recog");
+    // system("killall -9 face_recog");
     mtx.unlock();
 }
 
@@ -718,11 +722,15 @@ int main(int argc, char *argv[])
     ai_args.dump_img_dir = argv[15];
 
     /****fixed operation for ctrl+c****/
-    struct sigaction sa;
+    struct sigaction sa, sa_abrt;
     memset( &sa, 0, sizeof(sa) );
+    memset(&sa_abrt, 0, sizeof(sa_abrt));
     sa.sa_handler = fun_sig;
     sigfillset(&sa.sa_mask);
     sigaction(SIGINT, &sa, NULL);
+    sa_abrt.sa_handler = fun_sig_abrt;
+    sigfillset(&sa_abrt.sa_mask);
+    sigaction(SIGABRT, &sa_abrt, NULL);
 
     // get screen resolution
     if (drm_get_resolution(NULL, &screen_width, &screen_height) < 0) {
@@ -757,7 +765,6 @@ int main(int argc, char *argv[])
 
     thread_ds0.join();
     thread_ds2.join();
-    thread_key.join();
     memset(drm_dev.drm_bufs_argb[0].map, 0xff, screen_width * screen_height * 4);
     usleep(100000);
     drm_dmabuf_set_plane(&drm_dev.drm_bufs[0], &drm_dev.drm_bufs_argb[0]);
@@ -770,6 +777,6 @@ int main(int argc, char *argv[])
     {
         drm_destory_dumb(&drm_dev.drm_bufs_argb[i]);
     }
-	mediactl_exit();     
+	mediactl_exit();
     return 0;
 }

--- a/package/ai/code/face_recog/retinaface.cc
+++ b/package/ai/code/face_recog/retinaface.cc
@@ -103,6 +103,7 @@ void retinaface::prepare_memory()
         if(ioctl(share_memory, SHARE_MEMORY_ALIGN_ALLOC, &allocAlignMemFdInput[i]) < 0) 
         {
             std::cerr << "alloc allocAlignMemFdInput error" << std::endl;
+            // FIXME: share memory leak
             std::abort();
         }
         virtual_addr_input[i] = (char *)mmap(NULL, allocAlignMemFdInput[i].size, PROT_READ | PROT_WRITE, MAP_SHARED, mem_map, allocAlignMemFdInput[i].phyAddr);
@@ -400,7 +401,7 @@ retinaface::~retinaface()
             if(ioctl(share_memory, SHARE_MEMORY_FREE, &allocAlignMemFdInput[i].phyAddr) < 0) 
             {
                 std::cerr << "free allocAlignMemFdInput error" << std::endl;
-                std::abort();
+                // std::abort();
             }
         }
     }
@@ -412,7 +413,7 @@ retinaface::~retinaface()
         if(ioctl(share_memory, SHARE_MEMORY_FREE, &allocAlignMemFdOutput.phyAddr) < 0) 
         {
             std::cerr << "free allocAlignMemFdOutput error" << std::endl;
-            std::abort();
+            // std::abort();
         }
     }
     close(share_memory);


### PR DESCRIPTION
Child thread display_worker() invoke kill -9 to self process at exit, remove it. Ctrl-C can't exit because the GPIO key thread stuck on read(), main() exit will cancel that thread and raise an exception, use SIGART to handle.

Signed-off-by: 黄子懿 <huangziyi@canaan-creative.com>

<!--
请按照以下要求填写此PR模板
1. 根据此PR的类型在右侧'Labels'位置添加对应的label。比如此PR修复了某个bug，则添加'bug'label；此PR新增了某个feature，则添加'feature'label。
2. 在'PR描述'项里填写此PR解决了什么问题，比如修复了某个bug或新增了某个feature。
3. 在'详细描述'项里根据PR类型填写详细信息。比如此PR修复了某个bug，则填写bug的根本原因，您是如何解决的；此PR新增了某个feature，则填写您是如何实现的。
4. 在'关联issue'项里填写相关issue号(输入'#'会自动提示issue)，推荐使用'close'、'fix'、'resolve'等关键字进行自动关联(如'fix #1')，也可以提交PR后在右侧'Development'中进行手动关联。
-->

## PR描述:


## 详细描述:


## 关联issue:

fix #386 

<!--
请将#之后的X，手动修改为PR关联的issue ID, PR合并成功后，可以自动关闭对应的issue
Example: 
fix #1
-->
