### PR TITLE
The number of temperature sensors that read the temperature was reduc…

### DIFF
--- a/package/patches/linux/0040-The-number-of-temperature-sensors-that-read-the-temp.patch
+++ b/package/patches/linux/0040-The-number-of-temperature-sensors-that-read-the-temp.patch
@@ -1,0 +1,26 @@
+From 832b1aa92c0ca62127151ceef2c2c78690f1822b Mon Sep 17 00:00:00 2001
+From: liusuntao <1528681067@qq.com>
+Date: Mon, 21 Nov 2022 19:44:17 +0800
+Subject: [PATCH] The number of temperature sensors that read the temperature
+ was reduced from five to three.
+
+---
+ drivers/thermal/canaan_thermal.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/thermal/canaan_thermal.c b/drivers/thermal/canaan_thermal.c
+index 78cdd60..cc014d9 100755
+--- a/drivers/thermal/canaan_thermal.c
++++ b/drivers/thermal/canaan_thermal.c
+@@ -89,7 +89,7 @@ static int read_temp_single(struct canaan_thermal_data *data,
+     val = ioread32(data->base + TS_STATUS);
+     if(val == 0)
+         return -EAGAIN;
+-    for(bit = 0; bit < 5; bit++)
++    for(bit = 2; bit < 5; bit++)
+     {
+         if((val>>bit) & 0x1)
+         {
+-- 
+2.36.1
+


### PR DESCRIPTION
…ed from five to three.

<!--
请按照以下要求填写此PR模板
1. 根据此PR的类型在右侧'Labels'位置添加对应的label。比如此PR修复了某个bug，则添加'bug'label；此PR新增了某个feature，则添加'feature'label。
2. 在'PR描述'项里填写此PR解决了什么问题，比如修复了某个bug或新增了某个feature。
3. 在'详细描述'项里根据PR类型填写详细信息。比如此PR修复了某个bug，则填写bug的根本原因，您是如何解决的；此PR新增了某个feature，则填写您是如何实现的。
4. 在'关联issue'项里填写相关issue号(输入'#'会自动提示issue)，推荐使用'close'、'fix'、'resolve'等关键字进行自动关联(如'fix #1')，也可以提交PR后在右侧'Development'中进行手动关联。
-->

## PR描述:
Fixed the problem that the value read back by the sip board temperature sensor was incorrect.

## 详细描述:
The power supply pins of the first two temperature sensors in the sip chip are floating, so instead of reading the average value of five temperature sensors in the original drive, read the average value of three temperature sensors.

## 关联issue:
#393 
fix #X

<!--
请将#之后的X，手动修改为PR关联的issue ID, PR合并成功后，可以自动关闭对应的issue
Example: 
fix #1
-->
