### PR TITLE
fix  boot probability crash

### DIFF
--- a/board/canaan/k510/k510_rootfs_skeleton/etc/init.d/rc.sysinit
+++ b/board/canaan/k510/k510_rootfs_skeleton/etc/init.d/rc.sysinit
@@ -115,6 +115,6 @@ ntpdate  ntp.aliyun.com >/dev/null 2>&1 &
 i2ctransfer -f -y 0 w3@0x10 0x01 0x00 0x00
 
 cd /app/mediactl_lib/
-taskset 0x2 ./v4l2_drm.out -f video_drm_1920x1080.conf -e 1 -s &
+./v4l2_drm.out -f video_drm_1920x1080.conf -e 1 -s &
 cd /
 /usr/sbin/ifplugd -d 0 -u 0 -n -p  -I -i eth0 -r /etc/network/ifplug.sh &


### PR DESCRIPTION
<!--
请按照以下要求填写此PR模板
1. 根据此PR的类型在右侧'Labels'位置添加对应的label。比如此PR修复了某个bug，则添加'bug'label；此PR新增了某个feature，则添加'feature'label。
2. 在'PR描述'项里填写此PR解决了什么问题，比如修复了某个bug或新增了某个feature。
3. 在'详细描述'项里根据PR类型填写详细信息。比如此PR修复了某个bug，则填写bug的根本原因，您是如何解决的；此PR新增了某个feature，则填写您是如何实现的。
4. 在'关联issue'项里填写相关issue号(输入'#'会自动提示issue)，推荐使用'close'、'fix'、'resolve'等关键字进行自动关联(如'fix #1')，也可以提交PR后在右侧'Development'中进行手动关联。
-->

## PR描述:
fix  boot probability crash
## 详细描述:
解决系统启动时低概率crash问题，crash信息类似如下：
[   13.547009] k510-isp 92600000.isp1: k510isp_pipeline_set_stream:state(1)
[   13.554160] Unable to handle kernel NULL pointer dereference at virtual address 0000000000000000
[   13.563132] Oops [#1]
[   13.565418] Modules linked in:
[   13.568526] CPU: 1 PID: 166 Comm: v4l2_drm.out Not tainted 4.17.0 #6
[   13.574928] sepc: 0000000000000000 ra : 0000000000000001 sp : ffffffe009d6d9d0
[   13.582174]  gp : ffffffe000a2c458 tp : ffffffe0099d1280 t0 : 0000000000000000
[   13.589428]  t1 : fffffffffffeffff t2 : 0000000000000000 s0 : ffffffe00a3e6330
[   13.596677]  s1 : ffffffe00a3e2010 a0 : 0000000000000000 a1 : 0000000000000002
[   13.603908]  a2 : ffffffe000a2d7ac a3 : 0000000000000000 a4 : ffffffffffffffff
[   13.611135]  a5 : 0000000000000000 a6 : ffffffd0045d0014 a7 : 0000000000000008
[   13.618362]  s2 : ffffffe00a3e0018 s3 : ffffffe00a3c9100 s4 : 0000000000000001
[   13.625588]  s5 : 0000000000000005 s6 : 0000000000000001 s7 : 0000000000000001
[   13.632816]  s8 : ffffffe009d6d9c0 s9 : ffffffe000df6000 s10: 0000000200000022
[   13.640042]  s11: ffffffe00a3e0018 t3 : 0000000000000000 t4 : 0000000000000000
[   13.647268]  t5 : 0000000000000000 t6 : 0000000000000001
[   13.652584] sstatus: 0000000200000120 sbadaddr: 0000000000000000 scause: 000000000000000c
[   13.660772] CPU: 1 PID: 166 Comm: v4l2_drm.out Not tainted 4.17.0 #6
[   13.667128] Call Trace:
[   13.669602] [<ffffffe00003ac78>] walk_stackframe+0x0/0xa4
[   13.675012] [<ffffffe00003ae1c>] show_stack+0x2c/0x38
[   13.680073] [<ffffffe0006a027c>] dump_stack+0x64/0x80
[   13.685133] [<ffffffe00003a82c>] die+0x70/0xf8
[   13.689588] [<ffffffe00003d650>] do_page_fault+0x24c/0x358
[   13.695083] [<ffffffe000038f06>] ret_from_exception+0x0/0xc
[   13.700752] ---[ end trace 67e47d6cb31794e8 ]---
[   13.705394] Kernel panic - not syncing: Fatal exception in interrupt



## 关联issue:

fix #420 

<!--
请将#之后的X，手动修改为PR关联的issue ID, PR合并成功后，可以自动关闭对应的issue
Example: 
fix #1
-->
