### PR TITLE
fix #444: IOMUX GPIO18 conflict

### DIFF
--- a/package/patches/linux/0045-fix-IOMUX-GPIO18-conflict.patch
+++ b/package/patches/linux/0045-fix-IOMUX-GPIO18-conflict.patch
@@ -1,0 +1,30 @@
+From 56da9d07224dc5709d844c2b28b79f47ef294b63 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=E9=BB=84=E5=AD=90=E6=87=BF?=
+ <huangziyi@canaan-creative.com>
+Date: Thu, 2 Mar 2023 17:36:00 +0800
+Subject: [PATCH] fix IOMUX GPIO18 conflict
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: 黄子懿 <huangziyi@canaan-creative.com>
+---
+ arch/riscv/boot/dts/canaan/k510_crb_lp3_v1_2.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/riscv/boot/dts/canaan/k510_crb_lp3_v1_2.dts b/arch/riscv/boot/dts/canaan/k510_crb_lp3_v1_2.dts
+index dc5f58933..34c762dc4 100644
+--- a/arch/riscv/boot/dts/canaan/k510_crb_lp3_v1_2.dts
++++ b/arch/riscv/boot/dts/canaan/k510_crb_lp3_v1_2.dts
+@@ -221,7 +221,7 @@
+             (70) (FUNC_GPIO3) /*BT_RST_IN*/
+             (71) (FUNC_GPIO4) /*KEY_1*/
+             (72) (FUNC_GPIO17)
+-            (73) (FUNC_GPIO18)
++            (73) (FUNC_GPIO26)
+             (74) (FUNC_GPIO24)
+             (75) (FUNC_GPIO5) /*HP_INSERT_DET*/
+             (76) (FUNC_GPIO6) /*KEY_2*/
+-- 
+2.39.1
+


### PR DESCRIPTION
<!--
请按照以下要求填写此PR模板
1. 根据此PR的类型在右侧'Labels'位置添加对应的label。比如此PR修复了某个bug，则添加'bug'label；此PR新增了某个feature，则添加'feature'label。
2. 在'PR描述'项里填写此PR解决了什么问题，比如修复了某个bug或新增了某个feature。
3. 在'详细描述'项里根据PR类型填写详细信息。比如此PR修复了某个bug，则填写bug的根本原因，您是如何解决的；此PR新增了某个feature，则填写您是如何实现的。
4. 在'关联issue'项里填写相关issue号(输入'#'会自动提示issue)，推荐使用'close'、'fix'、'resolve'等关键字进行自动关联(如'fix #1')，也可以提交PR后在右侧'Development'中进行手动关联。
-->

## PR描述:
Fix IOMUX GPIO18 conflict IO73 and IO31, move IO73 to GPIO26

## 详细描述:


## 关联issue:

fix #444 

<!--
请将#之后的X，手动修改为PR关联的issue ID, PR合并成功后，可以自动关闭对应的issue
Example: 
fix #1
-->
