### PR TITLE
add ae y everage value get api

### DIFF
--- a/package/mediactl_lib/src/media_ctl.h
+++ b/package/mediactl_lib/src/media_ctl.h
@@ -169,6 +169,9 @@ int ir_cut_ev_set(enum isp_pipeline_e pipeline, enum ir_cut_mode_e ir_cut_mode, 
 float ir_cut_hold_time_get(enum isp_pipeline_e pipeline, enum ir_cut_mode_e ir_cut_mode);
 int ir_cut_hold_time_set(enum isp_pipeline_e pipeline, enum ir_cut_mode_e ir_cut_mode, float hold_time);
 
+/* ae state get API */
+int ae_y_average_get(enum isp_pipeline_e pipeline, unsigned int *value);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
请按照以下要求填写此PR模板
1. 根据此PR的类型在右侧'Labels'位置添加对应的label。比如此PR修复了某个bug，则添加'bug'label；此PR新增了某个feature，则添加'feature'label。
2. 在'PR描述'项里填写此PR解决了什么问题，比如修复了某个bug或新增了某个feature。
3. 在'详细描述'项里根据PR类型填写详细信息。比如此PR修复了某个bug，则填写bug的根本原因，您是如何解决的；此PR新增了某个feature，则填写您是如何实现的。
4. 在'关联issue'项里填写相关issue号(输入'#'会自动提示issue)，推荐使用'close'、'fix'、'resolve'等关键字进行自动关联(如'fix #1')，也可以提交PR后在右侧'Development'中进行手动关联。
-->

## PR描述:
media_ctl 增加亮度统计获取接口

## 详细描述:
传入不同的pipeline id，返回当前ISP的AE亮度统计值

demo
```c
unsigned int value = 0;
printf("%s, y everage before get: %d\n", __func__, value);
ae_y_everage_get(pipeline, &value);
printf("%s, y everage after get: %d\n", __func__, value);
return ret;
```

## 关联issue:

fix #449 

<!--
请将#之后的X，手动修改为PR关联的issue ID, PR合并成功后，可以自动关闭对应的issue
Example: 
fix #1
-->
